### PR TITLE
Fix markdown Accept negotiation

### DIFF
--- a/e2e/markdown-negotiation.spec.ts
+++ b/e2e/markdown-negotiation.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Markdown content negotiation", () => {
+	test("returns markdown for agent requests", async ({ request }) => {
+		const response = await request.get("/", {
+			headers: {
+				Accept: "text/markdown",
+			},
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()["content-type"]).toContain("text/markdown");
+		expect(response.headers()["x-markdown-tokens"]).toMatch(/^\d+$/);
+		await expect(response.text()).resolves.toContain("# Greg Nazario");
+	});
+
+	test("keeps HTML as the browser default", async ({ request }) => {
+		const response = await request.get("/", {
+			headers: {
+				Accept: "text/html",
+			},
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()["content-type"]).toContain("text/html");
+		await expect(response.text()).resolves.toContain("<!DOCTYPE html>");
+	});
+});

--- a/e2e/markdown-negotiation.spec.ts
+++ b/e2e/markdown-negotiation.spec.ts
@@ -27,14 +27,16 @@ test.describe("Markdown content negotiation", () => {
 	});
 
 	test("does not intercept well-known JSON endpoints", async ({ request }) => {
-		const response = await request.get("/.well-known/openid-configuration", {
+		const response = await request.get("/.well-known/api-catalog", {
 			headers: {
 				Accept: "text/markdown",
 			},
 		});
 
 		expect(response.status()).toBe(200);
-		expect(response.headers()["content-type"]).toContain("application/json");
+		expect(response.headers()["content-type"]).toContain(
+			"application/linkset+json",
+		);
 		expect(response.headers()["x-markdown-tokens"]).toBeUndefined();
 	});
 });

--- a/e2e/markdown-negotiation.spec.ts
+++ b/e2e/markdown-negotiation.spec.ts
@@ -11,7 +11,7 @@ test.describe("Markdown content negotiation", () => {
 		expect(response.status()).toBe(200);
 		expect(response.headers()["content-type"]).toContain("text/markdown");
 		expect(response.headers()["x-markdown-tokens"]).toMatch(/^\d+$/);
-		await expect(response.text()).resolves.toContain("# Greg Nazario");
+		await expect(response.text()).resolves.toContain("# gnazar.io");
 	});
 
 	test("keeps HTML as the browser default", async ({ request }) => {

--- a/e2e/markdown-negotiation.spec.ts
+++ b/e2e/markdown-negotiation.spec.ts
@@ -25,4 +25,16 @@ test.describe("Markdown content negotiation", () => {
 		expect(response.headers()["content-type"]).toContain("text/html");
 		await expect(response.text()).resolves.toContain("<!DOCTYPE html>");
 	});
+
+	test("does not intercept well-known JSON endpoints", async ({ request }) => {
+		const response = await request.get("/.well-known/openid-configuration", {
+			headers: {
+				Accept: "text/markdown",
+			},
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()["content-type"]).toContain("application/json");
+		expect(response.headers()["x-markdown-tokens"]).toBeUndefined();
+	});
 });

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,5 +1,4 @@
 import { createMiddleware, createStart } from "@tanstack/react-start";
-import { getStartContext } from "@tanstack/start-storage-context";
 
 import { approximateTokenCount } from "@/lib/agent-discovery";
 import {
@@ -77,6 +76,11 @@ function stripTrailingSlash(pathname: string): string {
 		return pathname.slice(0, -1);
 	}
 	return pathname;
+}
+
+function isPageLikePath(pathname: string): boolean {
+	const lastSegment = pathname.split("/").filter(Boolean).at(-1) ?? "";
+	return !lastSegment.includes(".");
 }
 
 async function markdownForPath(
@@ -242,18 +246,6 @@ No markdown representation is available for \`${url.pathname}\`.
 
 const markdownNegotiationMiddleware = createMiddleware().server(
 	async ({ next, request }) => {
-		const ctx = getStartContext({ throwIfNotFound: false });
-		if (!ctx) {
-			return next();
-		}
-		// Newer TanStack Start adds handlerType; omitting a direct property access keeps
-		// tsc happy when the lockfile resolves an older @tanstack/start-storage-context.
-		if (
-			"handlerType" in ctx &&
-			(ctx as { handlerType?: string }).handlerType !== "router"
-		) {
-			return next();
-		}
 		if (request.method !== "GET" && request.method !== "HEAD") {
 			return next();
 		}
@@ -262,6 +254,10 @@ const markdownNegotiationMiddleware = createMiddleware().server(
 		}
 
 		const url = new URL(request.url);
+		if (!isPageLikePath(url.pathname)) {
+			return next();
+		}
+
 		const result = await markdownForPath(url.pathname);
 
 		const varyHeaders = {

--- a/src/start.ts
+++ b/src/start.ts
@@ -79,7 +79,22 @@ function stripTrailingSlash(pathname: string): string {
 }
 
 function isPageLikePath(pathname: string): boolean {
-	const lastSegment = pathname.split("/").filter(Boolean).at(-1) ?? "";
+	const segments = pathname.split("/").filter(Boolean);
+	const baseSegments =
+		segments[0] && isValidLocale(segments[0]) ? segments.slice(1) : segments;
+
+	if (
+		baseSegments.some(
+			(segment) => segment.startsWith(".") || segment.startsWith("_"),
+		)
+	) {
+		return false;
+	}
+	if (baseSegments[0] === "api") {
+		return false;
+	}
+
+	const lastSegment = baseSegments.at(-1) ?? "";
 	return !lastSegment.includes(".");
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- serve markdown page representations directly from request middleware when `Accept: text/markdown` is preferred
- preserve HTML as the default for browser requests
- avoid intercepting special/internal endpoint paths such as `/.well-known/*`, `/_*`, and `/api/*`
- add Playwright coverage for markdown headers, browser HTML behavior, and well-known endpoint passthrough

## Testing
- `bun run lint`
- `bun run build`
- `bunx playwright test e2e/markdown-negotiation.spec.ts --project=chromium`
- Manual preview check: `Accept: text/markdown` returns `content-type: text/markdown; charset=utf-8` and `x-markdown-tokens`; default request returns `text/html; charset=utf-8`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c87e41be-fe83-4c43-849a-77fcf92b08aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c87e41be-fe83-4c43-849a-77fcf92b08aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

